### PR TITLE
Add unidirectional partition test

### DIFF
--- a/tests/framework/integration/cluster.go
+++ b/tests/framework/integration/cluster.go
@@ -1372,6 +1372,14 @@ func (m *Member) RecoverPartition(t testutil.TB, others ...*Member) {
 	}
 }
 
+// InjectUnidirectionalPartition drops one way connections from m to others.
+func (m *Member) InjectUnidirectionalPartition(t testutil.TB, others ...*Member) {
+	for _, other := range others {
+		m.Server.CutPeer(other.Server.MemberId())
+		t.Logf("one way network partition injected from %v to %v", m.Server.MemberId(), other.Server.MemberId())
+	}
+}
+
 func (m *Member) ReadyNotify() <-chan struct{} {
 	return m.Server.ReadyNotify()
 }


### PR DESCRIPTION
In some situations, a one-way network partition could occur, where the existing leader in an etcd cluster is able to receive vote requests from a candidate, but can't send responses back. This could obstruct the election of a new leader since the candidate may not receive sufficient votes without a response from the original leader.

Without a `PreVote `phase in place, this network partition could result in the original leader erroneously transitioning to a follower state. Furthermore, the etcd cluster would remain leaderless as it's unable to elect a new leader due to the lack of necessary votes.

This is why etcd implements a `PreVote` state. It acts as a preventive measure to maintain stability in the cluster and ensure a smooth transition of leadership, even in the face of network partitions.

To ensure this situation is adequately addressed, it is recommended to include unidirectional network partition tests in the test coverage.